### PR TITLE
update to latest libkv library

### DIFF
--- a/kviator.go
+++ b/kviator.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/etcd"
+	"github.com/docker/libkv/store/consul"
+	"github.com/docker/libkv/store/zookeeper"
 )
 
 const (

--- a/kviator.go
+++ b/kviator.go
@@ -122,10 +122,13 @@ func kvstoreConn(kvstore, client string) store.Store {
 	switch kvstore {
 	case "consul":
 		backend = store.CONSUL
+		consul.Register()
 	case "etcd":
 		backend = store.ETCD
+		etcd.Register()
 	case "zookeper":
 		backend = store.ZK
+		zookeeper.Register()
 	}
 	kv, err := libkv.NewStore(
 		backend,

--- a/kviator.go
+++ b/kviator.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	appName = "kviator"
-	version = "0.0.5"
+	version = "0.0.6"
 
 	helpText = `
 	kviator is a cli client for accessing consul, etcd, or zookeper KV.


### PR DESCRIPTION
libkv evolved and each backend now needs to be registered with the library.
libkv also update the etcd client to the official coreos supported client, replacing the deprecated go-etcd client.
